### PR TITLE
Community auth

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -239,6 +239,8 @@ Error
 "At least one mod is required",
 "Invalid ObjectId in mods array",
 "A community with this name already exists"
+"Not logged in"
+"Creator must be a mod"
 ```
 
 ### GET /community?id=(string)

--- a/backend/README.md
+++ b/backend/README.md
@@ -338,8 +338,7 @@ Body
 {
     "post" : {"content" : string,
                          "tags" : [string, ...]},
-    "community" : string,
-    "user" : string
+    "community" : string
 }
 ```
 
@@ -368,7 +367,7 @@ Error
 "A post must exist in a community",
 "Invalid community ID",
 "A user must make a post",
-"Invalid User ID"
+"Not logged in"
 ```
 
 ### GET /post?id=(string)
@@ -444,8 +443,7 @@ Body
 
 ```
 {
-    "post" : string,
-    "user" : string
+    "post" : string
 }
 ```
 
@@ -476,9 +474,8 @@ Error
 
 ```
 "No post ID provided",
-"No user ID provided",
 "Invalid post ID",
-"Invalid user ID",
+"Not logged in",
 "Post not found",
 "User has already liked this post"
 ```
@@ -489,8 +486,7 @@ Body
 
 ```
 {
-    "post" : string,
-    "user" : string
+    "post" : string
 }
 ```
 
@@ -521,9 +517,8 @@ Error
 
 ```
 "No post ID provided",
-"No user ID provided",
 "Invalid post ID",
-"Invalid user ID",
+"Not logged in",
 "Post not found, or internal server error",
 "User did not already like this post"
 ```
@@ -587,8 +582,7 @@ Body
     "comment" : {
         "content" : string
     },
-    "post" : string,
-    "user" : string
+    "post" : string
 }
 ```
 
@@ -605,15 +599,14 @@ Return
 }
 ```
 
-Error **These are not JSON objects, they are text**
+Error
 
 ```
 "No comment data",
 "There is no content in this comment",
 "A new top level comment requires a post ID",
 "Invalid post id",
-"No user ID given",
-"Invalid User ID"
+"Not logged in"
 ```
 
 ### GET /comment?id=(string)
@@ -646,7 +639,7 @@ Return
 ]
 ```
 
-Error **These are not JSON objects, they are text**
+Error
 
 ```
 "A post ID is required",

--- a/backend/src/communities/endpoints.js
+++ b/backend/src/communities/endpoints.js
@@ -3,11 +3,16 @@ import { Community } from './schemas.js';
 import { User } from '../authentication/schemas.js';
 
 // Community, requires community name, description, and at least one valid mod
-// The mod array  must comprise of correct Object IDs for User objects.
+// The mod array  must comprise of correct Object IDs for User objects, the creator must be in the mod array.
 export async function createCommunity(req, res) {
   const req_name = req.body.name;
   const req_desc = req.body.description;
   const req_mods = req.body.mods;
+
+  if (!req.isAuthenticated()) {
+    res.status(401).send({ error: 'not logged in' });
+    return;
+  }
 
   // Must have username and password
   if (!req_name) {
@@ -31,6 +36,11 @@ export async function createCommunity(req, res) {
   if (!isValidMods) {
     res.status(400).send({ error: 'Invalid ObjectId in mods array' });
     return;
+  }
+
+  // Mods list must include creator
+  if (!req.body.mods.includes(req.user._id)) {
+    res.status(400).send({ error: 'Creator must be a mod' });
   }
 
   //Determine if community name already exists

--- a/backend/src/communities/posts/comments/endpoints.js
+++ b/backend/src/communities/posts/comments/endpoints.js
@@ -6,37 +6,33 @@ import { Comment } from './schemas.js';
 export async function new_comment(req, res) {
   const comment = req.body.comment;
   const post_id = req.body.post;
-  const comment_user = req.body.user;
+
+  if (!req.isAuthenticated()) {
+    res.status(401).send({ error: 'not logged in' });
+    return;
+  }
+
+  const comment_user = req.user._id;
 
   const created_date = Date.now();
 
   if (!comment) {
-    res.status(400).send('No comment data');
+    res.status(400).send({ error: 'No comment data' });
     return;
   }
 
   if (!comment.content) {
-    res.status(400).send('There is no content in this comment');
+    res.status(400).send({ error: 'There is no content in this comment' });
     return;
   }
 
   if (!post_id) {
-    res.status(400).send('A new top level comment requires a post ID');
+    res.status(400).send({ error: 'A new top level comment requires a post ID' });
     return;
   }
 
   if (!mongoose.Types.ObjectId.isValid(post_id)) {
-    res.status(400).send('Invalid post id');
-    return;
-  }
-
-  if (!comment_user) {
-    res.status(400).send('No user ID given');
-    return;
-  }
-
-  if (!mongoose.Types.ObjectId.isValid(comment_user)) {
-    res.status(400).send('Invalid User ID');
+    res.status(400).send({ error: 'Invalid post id' });
     return;
   }
 
@@ -84,12 +80,12 @@ export async function get_comments_by_post(req, res) {
   const post = req.query.post;
 
   if (!post) {
-    res.status(400).send('A post ID is required');
+    res.status(400).send({ error: 'A post ID is required' });
     return;
   }
 
   if (!mongoose.Types.ObjectId.isValid(post)) {
-    res.status(400).send('Invalid post ID');
+    res.status(400).send({ error: 'Invalid post ID' });
     return;
   }
 
@@ -100,7 +96,7 @@ export async function get_comments_by_post(req, res) {
     })
     .exec((err, post) => {
       if (err) {
-        res.status(400).send('Internal Server Error');
+        res.status(500).send({ error: 'Internal Server Error' });
         return;
       }
 

--- a/backend/src/communities/posts/endpoints.js
+++ b/backend/src/communities/posts/endpoints.js
@@ -6,9 +6,15 @@ import { Post } from './schemas.js';
 export async function post_in_community(req, res) {
   const post = req.body.post;
   const post_comm = req.body.community;
-  const post_user = req.body.user;
 
   const created_date = Date.now();
+
+  if (!req.isAuthenticated()) {
+    res.status(401).send({ error: 'Not logged in' });
+    return;
+  }
+
+  const post_user = req.user._id;
 
   if (!post) {
     res.status(400).send({ error: 'No post data' });
@@ -32,11 +38,6 @@ export async function post_in_community(req, res) {
 
   if (!post_user) {
     res.status(400).send({ error: 'A user must make a post' });
-    return;
-  }
-
-  if (!mongoose.Types.ObjectId.isValid(post_user)) {
-    res.status(400).send({ error: 'Invalid User ID' });
     return;
   }
 
@@ -133,25 +134,21 @@ export async function get_posts_by_user_id(req, res) {
 //Likes a post given a user ID and post ID. Only if the like doesn't already exist.
 export async function like_post(req, res) {
   const post_id = req.body.post;
-  const user_id = req.body.user;
+
+  if (!req.isAuthenticated()) {
+    res.status(401).send({ error: 'Not logged in' });
+    return;
+  }
+
+  const user_id = req.user._id;
 
   if (!post_id) {
     res.status(400).send({ error: 'No post ID provided' });
     return;
   }
 
-  if (!user_id) {
-    res.status(400).send({ error: 'No user ID provided' });
-    return;
-  }
-
   if (!mongoose.Types.ObjectId.isValid(post_id)) {
     res.status(400).send({ error: 'Invalid post ID' });
-    return;
-  }
-
-  if (!mongoose.Types.ObjectId.isValid(user_id)) {
-    res.status(400).send({ error: 'Invalid user ID' });
     return;
   }
 
@@ -176,25 +173,20 @@ export async function like_post(req, res) {
 //Given a user ID and post ID, will remove a like from a post provided it was already there.
 export async function remove_like_post(req, res) {
   const post_id = req.body.post;
-  const user_id = req.body.user;
 
+  if (!req.isAuthenticated()) {
+    res.status(401).send({ error: 'Not logged in' });
+    return;
+  }
+
+  const user_id = req.user._id;
   if (!post_id) {
     res.status(400).send({ error: 'No post ID provided' });
     return;
   }
 
-  if (!user_id) {
-    res.status(400).send({ error: 'No user ID provided' });
-    return;
-  }
-
   if (!mongoose.Types.ObjectId.isValid(post_id)) {
     res.status(400).send({ error: 'Invalid post ID' });
-    return;
-  }
-
-  if (!mongoose.Types.ObjectId.isValid(user_id)) {
-    res.status(400).send({ error: 'Invalid user ID' });
     return;
   }
 

--- a/backend/tests/integration/communities/posts/comments/endpoints.test.js
+++ b/backend/tests/integration/communities/posts/comments/endpoints.test.js
@@ -10,61 +10,68 @@ import { Comment } from '../../../../../src/communities/posts/comments/schemas.j
 describe('POST /create_comment', () => {
   useMongoTestWrapper();
 
-  it('should fail due to no content', async () => {
+  it('should fail due to no auth', async () => {
     const app = await createTestApp();
+    const username = 'username';
+    const password = 'password';
 
-    const new_user = new User({
-      username: 'username',
-      password: 'password',
-    });
-    const user = await new_user.save();
+    let response = await request(app).post('/create_user').send({ username, password });
+    expect(response.statusCode).toBe(200);
+    const user = response.body;
 
     const new_post = new Post({
       content: 'Test content',
     });
     const post = await new_post.save();
 
-    let response = await request(app).post('/create_comment').send({ post: post._id, user: user._id });
-    expect(response.statusCode).toBe(400);
+    response = await request(app).post('/create_comment').send({ post: post._id });
+    expect(response.statusCode).toBe(401);
   });
 
-  it('should fail due to no user', async () => {
+  it('should fail due to no content', async () => {
     const app = await createTestApp();
+    const username = 'username';
+    const password = 'password';
+
+    let response = await request(app).post('/create_user').send({ username, password });
+    const cookie = response.headers['set-cookie'];
+    expect(response.statusCode).toBe(200);
+    const user = response.body;
 
     const new_post = new Post({
       content: 'Test content',
     });
     const post = await new_post.save();
 
-    const comment = { content: 'Test comment content' };
-
-    let response = await request(app).post('/create_comment').send({ post: post._id, comment });
+    response = await request(app).post('/create_comment').set('Cookie', cookie).send({ post: post._id });
     expect(response.statusCode).toBe(400);
   });
 
   it('should fail due to no post', async () => {
     const app = await createTestApp();
+    const username = 'username';
+    const password = 'password';
 
-    const new_user = new User({
-      username: 'username',
-      password: 'password',
-    });
-    const user = await new_user.save();
+    let response = await request(app).post('/create_user').send({ username, password });
+    const cookie = response.headers['set-cookie'];
+    expect(response.statusCode).toBe(200);
+    const user = response.body;
 
     const comment = { content: 'Test comment content' };
 
-    let response = await request(app).post('/create_comment').send({ user: user._id, comment });
+    response = await request(app).post('/create_comment').set('Cookie', cookie).send({ comment });
     expect(response.statusCode).toBe(400);
   });
 
   it('should make a new comment', async () => {
     const app = await createTestApp();
+    const username = 'username';
+    const password = 'password';
 
-    const new_user = new User({
-      username: 'username',
-      password: 'password',
-    });
-    const user = await new_user.save();
+    let response = await request(app).post('/create_user').send({ username, password });
+    const cookie = response.headers['set-cookie'];
+    expect(response.statusCode).toBe(200);
+    const user = response.body;
 
     const new_post = new Post({
       content: 'Test content',
@@ -73,7 +80,7 @@ describe('POST /create_comment', () => {
 
     const comment = { content: 'Test comment content' };
 
-    let response = await request(app).post('/create_comment').send({ user: user._id, post: post._id, comment });
+    response = await request(app).post('/create_comment').set('Cookie', cookie).send({ post: post._id, comment });
     expect(response.statusCode).toBe(200);
     expect(response.body.content).toBe(comment.content);
   });
@@ -141,12 +148,13 @@ describe('GET /comment', () => {
 
   it('should return Comment object', async () => {
     const app = await createTestApp();
+    const username = 'username';
+    const password = 'password';
 
-    const new_user = new User({
-      username: 'username',
-      password: 'password',
-    });
-    const user = await new_user.save();
+    let response = await request(app).post('/create_user').send({ username, password });
+    const cookie = response.headers['set-cookie'];
+    expect(response.statusCode).toBe(200);
+    const user = response.body;
 
     const new_post = new Post({
       content: 'Test content',
@@ -155,7 +163,10 @@ describe('GET /comment', () => {
 
     const comment = { content: 'Test comment content' };
 
-    let response = await request(app).post('/create_comment').send({ user: user._id, post: post._id, comment });
+    response = await request(app)
+      .post('/create_comment')
+      .set('cookie', cookie)
+      .send({ user: user._id, post: post._id, comment });
     expect(response.statusCode).toBe(200);
     const id = response.body._id;
 

--- a/backend/tests/integration/communities/posts/endpoints.test.js
+++ b/backend/tests/integration/communities/posts/endpoints.test.js
@@ -19,11 +19,13 @@ describe('POST /create_post', () => {
     const description = 'description';
 
     let response = await request(app).post('/create_user').send({ username, password });
+    const cookie = response.headers['set-cookie'];
     expect(response.statusCode).toBe(200);
     const user = response.body;
 
     response = await request(app)
       .post('/create_community')
+      .set('Cookie', cookie)
       .send({ name, description, mods: [user._id] });
     expect(response.statusCode).toBe(200);
     const community = response.body;
@@ -42,11 +44,13 @@ describe('POST /create_post', () => {
     const description = 'description';
 
     let response = await request(app).post('/create_user').send({ username, password });
+    const cookie = response.headers['set-cookie'];
     expect(response.statusCode).toBe(200);
     const user = response.body;
 
     response = await request(app)
       .post('/create_community')
+      .set('Cookie', cookie)
       .send({ name, description, mods: [user._id] });
     expect(response.statusCode).toBe(200);
     const community = response.body;
@@ -65,6 +69,7 @@ describe('POST /create_post', () => {
     const description = 'description';
 
     let response = await request(app).post('/create_user').send({ username, password });
+    const cookie = response.headers['set-cookie'];
     expect(response.statusCode).toBe(200);
     const user = response.body;
 
@@ -82,11 +87,13 @@ describe('POST /create_post', () => {
     const description = 'description';
 
     let response = await request(app).post('/create_user').send({ username, password });
+    const cookie = response.headers['set-cookie'];
     expect(response.statusCode).toBe(200);
     const user = response.body;
 
     response = await request(app)
       .post('/create_community')
+      .set('Cookie', cookie)
       .send({ name, description, mods: [user._id] });
     expect(response.statusCode).toBe(200);
     const community = response.body;
@@ -412,11 +419,13 @@ describe('GET /post', () => {
     const app = await createTestApp();
 
     let response = await request(app).post('/create_user').send({ username, password });
+    const cookie = response.headers['set-cookie'];
     expect(response.statusCode).toBe(200);
     const user = response.body;
 
     response = await request(app)
       .post('/create_community')
+      .set('Cookie', cookie)
       .send({ name, description, mods: [user._id] });
     expect(response.statusCode).toBe(200);
     const community = response.body;


### PR DESCRIPTION
Added authentication for POST and DELETE endpoints in community, post, and comment

Creator must be a mod in /create_community to prevent someone from making a community that can't edited later