### PR TITLE
Community boards

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -393,6 +393,28 @@ Errors
 403
 ```
 
+### GET /board?id={string}
+
+Returns Board object
+
+Errors
+
+```
+400
+404
+```
+
+### GET /community/boards?id={string}
+
+Returns Board object array
+
+Errors
+
+```
+400
+404
+```
+
 ### POST /create_post
 
 Body

--- a/backend/README.md
+++ b/backend/README.md
@@ -372,6 +372,27 @@ Errors
 409
 ```
 
+### DELETE /board
+
+Body
+
+```
+{
+    "board": string
+}
+```
+
+Returns "Deleted"
+
+Errors
+
+```
+400
+404
+401
+403
+```
+
 ### POST /create_post
 
 Body

--- a/backend/README.md
+++ b/backend/README.md
@@ -427,32 +427,16 @@ Body
 }
 ```
 
-Return
+### GET /board/posts?id={string}
 
-```
-{
-    "content": string,
-    "created_by": string,
-    "created_date": Date,
-    "tags": [string,
-        ...
-    ],
-    "liked_by": [],
-    "comments": [],
-    "_id": string,
-    "__v": number
-}
-```
+Returns Post object array
 
 Error
 
 ```
-"No post data",
-"There is no content in the post",
-"A post must exist in a board",
-"Invalid board ID",
-"A user must make a post",
-"Not logged in"
+400
+404
+```
 
 ### POST /create_post
 
@@ -871,4 +855,7 @@ Error
 ### GET /test_auth
 
 Returns a message to test your auth status
+
+```
+
 ```

--- a/backend/README.md
+++ b/backend/README.md
@@ -349,6 +349,29 @@ Return
 }
 ```
 
+### POST /create_board
+
+Body
+
+```
+{
+    "name": string,
+    "community": string
+}
+```
+
+Returns Board object
+
+Errors
+
+```
+400
+404
+401
+403
+409
+```
+
 ### POST /create_post
 
 Body

--- a/backend/README.md
+++ b/backend/README.md
@@ -349,7 +349,7 @@ Return
 }
 ```
 
-### POST /create_board
+### POST /board
 
 Body
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -415,7 +415,7 @@ Errors
 404
 ```
 
-### POST /create_post
+### POST /board/post
 
 Body
 
@@ -423,7 +423,7 @@ Body
 {
     "post" : {"content" : string,
                          "tags" : [string, ...]},
-    "community" : string
+    "board" : string
 }
 ```
 
@@ -449,10 +449,55 @@ Error
 ```
 "No post data",
 "There is no content in the post",
+"A post must exist in a board",
+"Invalid board ID",
+"A user must make a post",
+"Not logged in"
+
+### POST /create_post
+
+Body
+
+```
+
+{
+"post" : {"content" : string,
+"tags" : [string, ...]},
+"community" : string
+}
+
+```
+
+Return
+
+```
+
+{
+"content": string,
+"created_by": string,
+"created_date": Date,
+"tags": [string,
+...
+],
+"liked_by": [],
+"comments": [],
+"\_id": string,
+"\_\_v": number
+}
+
+```
+
+Error
+
+```
+
+"No post data",
+"There is no content in the post",
 "A post must exist in a community",
 "Invalid community ID",
 "A user must make a post",
 "Not logged in"
+
 ```
 
 ### DELETE /post
@@ -460,18 +505,22 @@ Error
 Body
 
 ```
+
 {
-    post: string
+post: string
 }
+
 ```
 
 Error
 
 ```
+
 Post missing
 Post not found
 Not logged in
 Not creator of post
+
 ```
 
 ### GET /post?id=(string)
@@ -481,7 +530,9 @@ Returns Post object
 Errors
 
 ```
+
 400, 404
+
 ```
 
 ### GET /community/posts?community=(string)
@@ -489,28 +540,32 @@ Errors
 Return
 
 ```
+
 [
-    {
-        "_id": string,
-        "content": string,
-        "created_by": string,
-        "created_date": Date,
-        "tags": [
-            String, ...
-        ],
-        "liked_by": [ (string)UserId, ...],
-        "comments": [ (string)CommentId, ... ],
-        "__v": number
-    },
-    ...
+{
+"\_id": string,
+"content": string,
+"created_by": string,
+"created_date": Date,
+"tags": [
+String, ...
+],
+"liked_by": [ (string)UserId, ...],
+"comments": [ (string)CommentId, ... ],
+"\_\_v": number
+},
+...
 ]
+
 ```
 
 Error
 
 ```
+
 "A community is required",
 "Invalid Community ID"
+
 ```
 
 ### GET /user/posts?user_id=(string)
@@ -518,27 +573,31 @@ Error
 Return
 
 ```
+
 [
-    {
-        "_id": string,
-        "content": string,
-        "created_by": string,
-        "created_date": Date,
-        "tags": [
-            String, ...
-        ],
-        "liked_by": [ (string)UserId, ...],
-        "comments": [ (string)CommentId, ...],
-        "__v": number
-    }
+{
+"\_id": string,
+"content": string,
+"created_by": string,
+"created_date": Date,
+"tags": [
+String, ...
+],
+"liked_by": [ (string)UserId, ...],
+"comments": [ (string)CommentId, ...],
+"\_\_v": number
+}
 ]
+
 ```
 
 Error
 
 ```
+
 "A user is required",
 "Invalid Community ID"
+
 ```
 
 ### POST /like/post
@@ -546,42 +605,48 @@ Error
 Body
 
 ```
+
 {
-    "post" : string
+"post" : string
 }
+
 ```
 
 Return
 
 ```
+
 {
-    "_id": string,
-    "content": string,
-    "created_by": string,
-    "created_date": Date,
-    "tags": [
-        string, ...
-    ],
-    "liked_by": [
-        (string)UserId,
-        ...
-    ],
-    "comments": [
-        (string)CommentId,
-        ...
-    ],
-    "__v": number
+"\_id": string,
+"content": string,
+"created_by": string,
+"created_date": Date,
+"tags": [
+string, ...
+],
+"liked_by": [
+(string)UserId,
+...
+],
+"comments": [
+(string)CommentId,
+...
+],
+"\_\_v": number
 }
+
 ```
 
 Error
 
 ```
+
 "No post ID provided",
 "Invalid post ID",
 "Not logged in",
 "Post not found",
 "User has already liked this post"
+
 ```
 
 ### DELETE /like/post
@@ -589,42 +654,48 @@ Error
 Body
 
 ```
+
 {
-    "post" : string
+"post" : string
 }
+
 ```
 
 Return
 
 ```
+
 {
-    "_id": string,
-    "content": string,
-    "created_by": string,
-    "created_date": Date,
-    "tags": [
-        string, ...
-    ],
-    "liked_by": [
-        (string)UserId,
-        ...
-    ],
-    "comments": [
-        (string)CommentId,
-        ...
-    ],
-    "__v": number
+"\_id": string,
+"content": string,
+"created_by": string,
+"created_date": Date,
+"tags": [
+string, ...
+],
+"liked_by": [
+(string)UserId,
+...
+],
+"comments": [
+(string)CommentId,
+...
+],
+"\_\_v": number
 }
+
 ```
 
 Error
 
 ```
+
 "No post ID provided",
 "Invalid post ID",
 "Not logged in",
 "Post not found, or internal server error",
 "User did not already like this post"
+
 ```
 
 ### GET /post/likes?post=(string)
@@ -632,23 +703,27 @@ Error
 Return
 
 ```
+
 [
-    {
-        "_id": string,
-        "username": string,
-        "password_hash": string,
-        "salt": string,
-        "__v": number
-    },
-    ...
+{
+"_id": string,
+"username": string,
+"password_hash": string,
+"salt": string,
+"__v": number
+},
+...
 ]
+
 ```
 
 Error
 
 ```
+
 "No post ID provided",
 "Invalid post ID"
+
 ```
 
 ### GET /post/user_liked?post=(string)&user=(string)
@@ -658,23 +733,29 @@ Return
 if user liked
 
 ```
+
 1
+
 ```
 
 if user not liked
 
 ```
+
 0
+
 ```
 
 Error
 
 ```
+
 "No post ID provided",
 "No user ID provided",
 "Invalid post ID",
 "Invalid user ID",
 "Post not found"
+
 ```
 
 ### POST /create_comment
@@ -682,35 +763,41 @@ Error
 Body
 
 ```
+
 {
-    "comment" : {
-        "content" : string
-    },
-    "post" : string
+"comment" : {
+"content" : string
+},
+"post" : string
 }
+
 ```
 
 Return
 
 ```
+
 {
-    "content": string,
-    "children_comments": [],
-    "created_by": string,
-    "created_date": string,
-    "_id": string,
-    "__v": number
+"content": string,
+"children_comments": [],
+"created_by": string,
+"created_date": string,
+"\_id": string,
+"\_\_v": number
 }
+
 ```
 
 Error
 
 ```
+
 "No comment data",
 "There is no content in this comment",
 "A new top level comment requires a post ID",
 "Invalid post id",
 "Not logged in"
+
 ```
 
 ### DELETE /comment
@@ -718,18 +805,22 @@ Error
 Body
 
 ```
+
 {
-    comment: string
+comment: string
 }
+
 ```
 
 Error
 
 ```
+
 Comment missing
 Comment not found
 Not logged in
 Not creator of comment
+
 ```
 
 ### GET /comment?id=(string)
@@ -739,7 +830,9 @@ Returns Comment object
 Errors
 
 ```
+
 400, 404
+
 ```
 
 ### GET /post/comments
@@ -747,26 +840,30 @@ Errors
 Return
 
 ```
+
 [
-    {
-        "_id": string,
-        "content": string,
-        "children_comments": [
-            (string)CommentId, ...
-        ],
-        "created_by": string,
-        "created_date": Date,
-        "__v": number
-    },
-    ...
+{
+"\_id": string,
+"content": string,
+"children_comments": [
+(string)CommentId, ...
+],
+"created_by": string,
+"created_date": Date,
+"\_\_v": number
+},
+...
 ]
+
 ```
 
 Error
 
 ```
+
 "A post ID is required",
 "Invalid post ID"
+
 ```
 
 ## Debug Endpoints (only exposed when testing)
@@ -774,3 +871,4 @@ Error
 ### GET /test_auth
 
 Returns a message to test your auth status
+```

--- a/backend/src/communities/boards/endpoints.js
+++ b/backend/src/communities/boards/endpoints.js
@@ -66,3 +66,48 @@ export async function createBoard(req, res, next) {
   res.status(200).send(new_board);
   return;
 }
+
+export async function deleteBoard(req, res, next) {
+  const boardId = req.body.board;
+
+  // must have a board id
+  if (!boardId) {
+    res.status(400).send({ error: 'board missing' });
+    return;
+  }
+
+  // board must be valid
+  if (!mongoose.Types.ObjectId.isValid(boardId)) {
+    res.status(404).send({ error: 'board not found' });
+    return;
+  }
+  let board = await Board.findById(boardId);
+  if (!board) {
+    res.status(404).send({ error: 'board not found' });
+    return;
+  }
+  let community = await Community.findById(board.parent);
+
+  // must be logged in
+  if (!req.isAuthenticated()) {
+    res.status(401).send({ error: 'not logged in' });
+    return;
+  }
+  const user = await User.findById(req.user._id);
+
+  // must be a mod in the community
+  if (!community.mods.includes(user._id)) {
+    res.status(403).send({ error: 'not mod in community' });
+    return;
+  }
+
+  // remove board from community
+  community.boards = community.boards.filter((b) => !b.equals(board._id));
+  await community.save();
+
+  // delete the board
+  await board.deleteRecursive();
+
+  res.status(200).send('Deleted');
+  return;
+}

--- a/backend/src/communities/boards/endpoints.js
+++ b/backend/src/communities/boards/endpoints.js
@@ -227,3 +227,27 @@ export async function postInBoard(req, res) {
 
   res.status(200).json(posted);
 }
+
+export async function getBoardPosts(req, res, next) {
+  const id = req.query.id;
+
+  // must have id
+  if (!id) {
+    res.status(400).send({ error: 'id missing' });
+    return;
+  }
+
+  // id must be valid
+  if (!mongoose.Types.ObjectId.isValid(id)) {
+    res.status(404).send({ error: 'board not found' });
+    return;
+  }
+  let board = await Board.findById(id).populate('posts');
+  if (!board) {
+    res.status(404).send({ error: 'board not found' });
+    return;
+  }
+
+  //send the posts
+  res.status(200).send(board.posts);
+}

--- a/backend/src/communities/boards/endpoints.js
+++ b/backend/src/communities/boards/endpoints.js
@@ -111,3 +111,51 @@ export async function deleteBoard(req, res, next) {
   res.status(200).send('Deleted');
   return;
 }
+
+export async function getBoard(req, res, next) {
+  const id = req.query.id;
+
+  // must have id
+  if (!id) {
+    res.status(400).send({ error: 'id missing' });
+    return;
+  }
+
+  // id must be valid
+  if (!mongoose.Types.ObjectId.isValid(id)) {
+    res.status(404).send({ error: 'board not found' });
+    return;
+  }
+  let board = await Board.findById(id);
+  if (!board) {
+    res.status(404).send({ error: 'board not found' });
+    return;
+  }
+
+  // send the board
+  res.status(200).send(board);
+}
+
+export async function getCommunityBoards(req, res, next) {
+  const id = req.query.id;
+
+  // must have id
+  if (!id) {
+    res.status(400).send({ error: 'id missing' });
+    return;
+  }
+
+  // id must be valid
+  if (!mongoose.Types.ObjectId.isValid(id)) {
+    res.status(404).send({ error: 'community not found' });
+    return;
+  }
+  let com = await Community.findById(id).populate('boards');
+  if (!com) {
+    res.status(404).send({ error: 'community not found' });
+    return;
+  }
+
+  //send the boards
+  res.status(200).send(com.boards);
+}

--- a/backend/src/communities/boards/endpoints.js
+++ b/backend/src/communities/boards/endpoints.js
@@ -1,0 +1,68 @@
+import mongoose from 'mongoose';
+
+import { Community } from '../schemas.js';
+import { Board } from './schemas.js';
+import { User } from '../../authentication/schemas.js';
+
+export async function createBoard(req, res, next) {
+  const name = req.body.name;
+  const communityId = req.body.community;
+
+  // must have a name
+  if (!name) {
+    res.status(400).send({ error: 'name missing' });
+    return;
+  }
+
+  // must have a community id
+  if (!communityId) {
+    res.status(400).send({ error: 'community missing' });
+    return;
+  }
+
+  // community must be valid
+  if (!mongoose.Types.ObjectId.isValid(communityId)) {
+    res.status(404).send({ error: 'community not found' });
+    return;
+  }
+  let community = await Community.findById(communityId).populate('boards');
+  if (!community) {
+    res.status(404).send({ error: 'community not found' });
+    return;
+  }
+
+  // must be logged in
+  if (!req.isAuthenticated()) {
+    res.status(401).send({ error: 'not logged in' });
+    return;
+  }
+  const user = await User.findById(req.user._id);
+
+  // must be a mod in the community
+  if (!community.mods.includes(user._id)) {
+    res.status(403).send({ error: 'not mod in community' });
+    return;
+  }
+
+  // board name must not be used in community already
+  if (!community.boards.every((b) => b.name != name)) {
+    res.status(409).send({ error: 'board name in use' });
+    return;
+  }
+
+  // create board
+  const new_board = new Board({
+    name: name,
+    parent: community._id,
+    posts: [],
+  });
+  await new_board.save();
+
+  // add board to community
+  community.boards.push(new_board._id);
+  await community.save();
+
+  // return the board object
+  res.status(200).send(new_board);
+  return;
+}

--- a/backend/src/communities/boards/index.js
+++ b/backend/src/communities/boards/index.js
@@ -1,10 +1,11 @@
-import { createBoard, deleteBoard, getBoard, getCommunityBoards } from './endpoints.js';
+import { createBoard, deleteBoard, getBoard, getCommunityBoards, postInBoard } from './endpoints.js';
 
 export default function useBoards(app) {
   app.post('/board', createBoard);
   app.delete('/board', deleteBoard);
   app.get('/board', getBoard);
   app.get('/community/boards', getCommunityBoards);
+  app.post('/board/post', postInBoard);
 
   return app;
 }

--- a/backend/src/communities/boards/index.js
+++ b/backend/src/communities/boards/index.js
@@ -1,4 +1,4 @@
-import { createBoard, deleteBoard, getBoard, getCommunityBoards, postInBoard } from './endpoints.js';
+import { createBoard, deleteBoard, getBoard, getBoardPosts, getCommunityBoards, postInBoard } from './endpoints.js';
 
 export default function useBoards(app) {
   app.post('/board', createBoard);
@@ -6,6 +6,7 @@ export default function useBoards(app) {
   app.get('/board', getBoard);
   app.get('/community/boards', getCommunityBoards);
   app.post('/board/post', postInBoard);
+  app.get('/board/posts', getBoardPosts);
 
   return app;
 }

--- a/backend/src/communities/boards/index.js
+++ b/backend/src/communities/boards/index.js
@@ -1,0 +1,7 @@
+import { createBoard } from './endpoints.js';
+
+export default function useBoards(app) {
+  app.post('/create_board', createBoard);
+
+  return app;
+}

--- a/backend/src/communities/boards/index.js
+++ b/backend/src/communities/boards/index.js
@@ -1,7 +1,8 @@
-import { createBoard } from './endpoints.js';
+import { createBoard, deleteBoard } from './endpoints.js';
 
 export default function useBoards(app) {
   app.post('/create_board', createBoard);
+  app.delete('/board', deleteBoard);
 
   return app;
 }

--- a/backend/src/communities/boards/index.js
+++ b/backend/src/communities/boards/index.js
@@ -1,8 +1,10 @@
-import { createBoard, deleteBoard } from './endpoints.js';
+import { createBoard, deleteBoard, getBoard, getCommunityBoards } from './endpoints.js';
 
 export default function useBoards(app) {
   app.post('/create_board', createBoard);
   app.delete('/board', deleteBoard);
+  app.get('/board', getBoard);
+  app.get('/community/boards', getCommunityBoards);
 
   return app;
 }

--- a/backend/src/communities/boards/index.js
+++ b/backend/src/communities/boards/index.js
@@ -1,7 +1,7 @@
 import { createBoard, deleteBoard, getBoard, getCommunityBoards } from './endpoints.js';
 
 export default function useBoards(app) {
-  app.post('/create_board', createBoard);
+  app.post('/board', createBoard);
   app.delete('/board', deleteBoard);
   app.get('/board', getBoard);
   app.get('/community/boards', getCommunityBoards);

--- a/backend/src/communities/boards/schemas.js
+++ b/backend/src/communities/boards/schemas.js
@@ -1,0 +1,52 @@
+import mongoose from 'mongoose';
+import { Post } from '../posts/schemas.js';
+import { Community } from '../schemas.js';
+const { Schema } = mongoose;
+
+const boardSchema = new Schema(
+  {
+    name: {
+      type: String,
+      unique: true,
+      required: true,
+    },
+    posts: [
+      {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'Post',
+      },
+    ],
+    parent: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Community',
+    },
+  },
+  {
+    methods: {
+      // remove all posts, remove from community, delete object
+      async deleteRecursive() {
+        const board = await Board.findById(this._id);
+
+        // delete all posts
+        for (const post of board.posts) {
+          const post_obj = await Post.findById(post);
+          if (post_obj) {
+            await post_obj.deleteRecursive();
+          }
+        }
+
+        // remove from community
+        const com = await Community.findById(board.parent);
+        if (com) {
+          com.boards = com.boards.filter((b) => !b.equals(board._id));
+          await com.save();
+        }
+
+        // delete the object
+        await board.delete();
+      },
+    },
+  },
+);
+
+export const Board = mongoose.model('Board', boardSchema);

--- a/backend/src/communities/index.js
+++ b/backend/src/communities/index.js
@@ -1,3 +1,4 @@
+import useBoards from './boards/index.js';
 import {
   createCommunity,
   query_communities,
@@ -46,6 +47,9 @@ export default function useCommunities(app) {
   app.get('/post/comments', get_comments_by_post);
   app.get('/comment', getComment);
   app.delete('/comment', deleteComment);
+
+  // board endpoints
+  app = useBoards(app);
 
   return app;
 }

--- a/backend/src/communities/schemas.js
+++ b/backend/src/communities/schemas.js
@@ -1,6 +1,7 @@
 import mongoose from 'mongoose';
 import { User } from '../authentication/schemas.js';
 import { Post } from './posts/schemas.js';
+import { Board } from './boards/schemas.js';
 const { Schema } = mongoose;
 
 const communitySchema = new Schema(
@@ -21,6 +22,12 @@ const communitySchema = new Schema(
       {
         type: mongoose.Schema.Types.ObjectId,
         ref: 'Post',
+      },
+    ],
+    boards: [
+      {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'Board',
       },
     ],
   },
@@ -58,6 +65,14 @@ const communitySchema = new Schema(
           const post_obj = await Post.findById(post);
           if (post_obj) {
             await post_obj.deleteRecursive();
+          }
+        }
+
+        // delete all boards
+        for (const board of com.boards) {
+          const board_obj = await Board.findById(board);
+          if (board_obj) {
+            await board_obj.deleteRecursive();
           }
         }
 

--- a/backend/tests/integration/communities/boards/endpoints.test.js
+++ b/backend/tests/integration/communities/boards/endpoints.test.js
@@ -3,6 +3,7 @@ import request from 'supertest';
 import createTestApp from '../../../../src/debug/test-app.js';
 import useMongoTestWrapper from '../../../../src/debug/jest-mongo.js';
 import { Community } from '../../../../src/communities/schemas.js';
+import { Board } from '../../../../src/communities/boards/schemas.js';
 
 describe('POST /create_board', () => {
   useMongoTestWrapper();
@@ -140,5 +141,130 @@ describe('POST /create_board', () => {
 
     response = await request(app).post('/create_board').set('Cookie', cookie).send({ name, community });
     expect(response.statusCode).toBe(409);
+  });
+});
+
+describe('DELETE /board', () => {
+  useMongoTestWrapper();
+
+  it('should fail with missing board', async () => {
+    const app = await createTestApp();
+    const board = '';
+
+    let response = await request(app).delete('/board').send({});
+    expect(response.statusCode).toBe(400);
+
+    response = await request(app).delete('/board').send({ board });
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('should fail with invalid board', async () => {
+    const app = await createTestApp();
+    const board = 'board';
+
+    let response = await request(app).delete('/board').send({ board });
+    expect(response.statusCode).toBe(404);
+  });
+
+  it('should fail when not logged in', async () => {
+    const app = await createTestApp();
+    const username = 'username';
+    const password = 'password';
+    const name = 'board';
+
+    let response = await request(app).post('/create_user').send({ username, password });
+    expect(response.statusCode).toBe(200);
+    const cookie = response.headers['set-cookie'];
+    const user = response.body;
+
+    const comm_name = 'test community';
+    const comm_desc = 'a test community';
+    response = await request(app)
+      .post('/create_community')
+      .set('Cookie', cookie)
+      .send({ name: comm_name, description: comm_desc, mods: [user._id] });
+    expect(response.statusCode).toBe(200);
+    const community = response.body._id;
+
+    response = await request(app).post('/create_board').set('Cookie', cookie).send({ name, community });
+    expect(response.statusCode).toBe(200);
+    let board = response.body._id;
+
+    response = await request(app).delete('/board').send({ board });
+    expect(response.statusCode).toBe(401);
+  });
+
+  it('should fail when not mod', async () => {
+    const app = await createTestApp();
+    const username = 'username';
+    const password = 'password';
+    const name = 'board';
+
+    let response = await request(app).post('/create_user').send({ username, password });
+    expect(response.statusCode).toBe(200);
+    const cookie = response.headers['set-cookie'];
+    const user = response.body;
+
+    response = await request(app).post('/create_user').send({ username: 'wow', password });
+    expect(response.statusCode).toBe(200);
+    const cookie2 = response.headers['set-cookie'];
+    const user2 = response.body;
+
+    const comm_name = 'test community';
+    const comm_desc = 'a test community';
+    response = await request(app)
+      .post('/create_community')
+      .set('Cookie', cookie2)
+      .send({ name: comm_name, description: comm_desc, mods: [user2._id] });
+    expect(response.statusCode).toBe(200);
+    const community = response.body._id;
+
+    response = await request(app).post('/create_board').set('Cookie', cookie2).send({ name, community });
+    expect(response.statusCode).toBe(200);
+    let board = response.body._id;
+
+    response = await request(app).delete('/board').set('Cookie', cookie).send({ board });
+    expect(response.statusCode).toBe(403);
+  });
+
+  it('should delete the board and follow procedure', async () => {
+    const app = await createTestApp();
+    const username = 'username';
+    const password = 'password';
+    const name = 'board';
+
+    let response = await request(app).post('/create_user').send({ username, password });
+    expect(response.statusCode).toBe(200);
+    const cookie = response.headers['set-cookie'];
+    const user = response.body;
+
+    const comm_name = 'test community';
+    const comm_desc = 'a test community';
+    response = await request(app)
+      .post('/create_community')
+      .set('Cookie', cookie)
+      .send({ name: comm_name, description: comm_desc, mods: [user._id] });
+    expect(response.statusCode).toBe(200);
+    let community = response.body._id;
+
+    response = await request(app).post('/create_board').set('Cookie', cookie).send({ name, community });
+    expect(response.statusCode).toBe(200);
+    const board = response.body;
+    expect(board.name).toBe(name);
+    expect(board.parent).toBe(community);
+    expect((await Board.find()).length).toBe(1);
+
+    community = await Community.findById(community);
+    expect(community.boards.length).toBe(1);
+    expect(community.boards.includes(board._id)).toBe(true);
+
+    response = await request(app).delete('/board').set('Cookie', cookie).send({ board: board._id });
+    expect(response.statusCode).toBe(200);
+
+    expect((await Board.find()).length).toBe(0);
+    community = await Community.findById(community);
+    expect(community.boards.length).toBe(0);
+
+    // TODO delete board deletes posts
   });
 });

--- a/backend/tests/integration/communities/boards/endpoints.test.js
+++ b/backend/tests/integration/communities/boards/endpoints.test.js
@@ -4,6 +4,9 @@ import createTestApp from '../../../../src/debug/test-app.js';
 import useMongoTestWrapper from '../../../../src/debug/jest-mongo.js';
 import { Community } from '../../../../src/communities/schemas.js';
 import { Board } from '../../../../src/communities/boards/schemas.js';
+import { User } from '../../../../src/authentication/schemas.js';
+import { Post } from '../../../../src/communities/posts/schemas.js';
+import { Comment } from '../../../../src/communities/posts/comments/schemas.js';
 
 describe('POST /board', () => {
   useMongoTestWrapper();
@@ -254,6 +257,12 @@ describe('DELETE /board', () => {
     expect(board.parent).toBe(community);
     expect((await Board.find()).length).toBe(1);
 
+    let post = { content: 'Test' };
+    response = await request(app).post('/board/post').set('Cookie', cookie).send({ post, board: board._id });
+    expect(response.statusCode).toBe(200);
+    post = response.body;
+    expect((await Post.find()).length).toBe(1);
+
     community = await Community.findById(community);
     expect(community.boards.length).toBe(1);
     expect(community.boards.includes(board._id)).toBe(true);
@@ -261,11 +270,15 @@ describe('DELETE /board', () => {
     response = await request(app).delete('/board').set('Cookie', cookie).send({ board: board._id });
     expect(response.statusCode).toBe(200);
 
+    // board should not be in database
     expect((await Board.find()).length).toBe(0);
+
+    // community should have no boards
     community = await Community.findById(community);
     expect(community.boards.length).toBe(0);
 
-    // TODO delete board deletes posts
+    // post should be deleted
+    expect((await Post.find()).length).toBe(0);
   });
 });
 
@@ -375,5 +388,242 @@ describe('GET /community/boards', () => {
     expect(got_boards.length).toBe(1);
     expect(got_boards[0].name).toBe(name);
     expect(got_boards[0].parent).toBe(community);
+  });
+});
+
+describe('POST /board/post', () => {
+  useMongoTestWrapper();
+
+  it('should fail due to no auth', async () => {
+    const app = await createTestApp();
+
+    const username = 'username';
+    const password = 'password';
+    const name = 'name';
+    const description = 'description';
+
+    let response = await request(app).post('/create_user').send({ username, password });
+    const cookie = response.headers['set-cookie'];
+    expect(response.statusCode).toBe(200);
+    const user = response.body;
+
+    response = await request(app)
+      .post('/create_community')
+      .set('Cookie', cookie)
+      .send({ name, description, mods: [user._id] });
+    expect(response.statusCode).toBe(200);
+    const community = response.body._id;
+
+    response = await request(app).post('/board').set('Cookie', cookie).send({ name, community });
+    expect(response.statusCode).toBe(200);
+    let board = response.body._id;
+
+    const post = {};
+    response = await request(app).post('/board/post').send({ post, board: board, user: user._id });
+    expect(response.statusCode).toBe(401);
+  });
+
+  it('should fail due to no content', async () => {
+    const app = await createTestApp();
+
+    const username = 'username';
+    const password = 'password';
+    const name = 'name';
+    const description = 'description';
+
+    let response = await request(app).post('/create_user').send({ username, password });
+    const cookie = response.headers['set-cookie'];
+    expect(response.statusCode).toBe(200);
+    const user = response.body;
+
+    response = await request(app)
+      .post('/create_community')
+      .set('Cookie', cookie)
+      .send({ name, description, mods: [user._id] });
+    expect(response.statusCode).toBe(200);
+    const community = response.body._id;
+
+    response = await request(app).post('/board').set('Cookie', cookie).send({ name, community });
+    expect(response.statusCode).toBe(200);
+    let board = response.body._id;
+
+    const post = {};
+    response = await request(app).post('/board/post').set('Cookie', cookie).send({ post, board, user: user._id });
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('should fail due to no board', async () => {
+    const app = await createTestApp();
+
+    const username = 'username';
+    const password = 'password';
+    const name = 'name';
+    const description = 'description';
+
+    let response = await request(app).post('/create_user').send({ username, password });
+    const cookie = response.headers['set-cookie'];
+    expect(response.statusCode).toBe(200);
+    const user = response.body;
+
+    const post = { content: 'Test' };
+    response = await request(app).post('/board/post').set('Cookie', cookie).send({ post, user: user._id });
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('should create a new post', async () => {
+    const app = await createTestApp();
+
+    const username = 'username';
+    const password = 'password';
+    const name = 'name';
+    const description = 'description';
+
+    let response = await request(app).post('/create_user').send({ username, password });
+    const cookie = response.headers['set-cookie'];
+    expect(response.statusCode).toBe(200);
+    const user = response.body;
+
+    response = await request(app)
+      .post('/create_community')
+      .set('Cookie', cookie)
+      .send({ name, description, mods: [user._id] });
+    expect(response.statusCode).toBe(200);
+    const community = response.body._id;
+
+    response = await request(app).post('/board').set('Cookie', cookie).send({ name, community });
+    expect(response.statusCode).toBe(200);
+    let board = response.body._id;
+
+    const post = { content: 'Test' };
+    response = await request(app).post('/board/post').set('Cookie', cookie).send({ post, board, user: user._id });
+    expect(response.statusCode).toBe(200);
+    expect(response.body.content).toBe(post.content);
+  });
+
+  it('should update parent and user', async () => {
+    const app = await createTestApp();
+
+    const username = 'username';
+    const password = 'password';
+    const name = 'name';
+    const description = 'description';
+
+    let response = await request(app).post('/create_user').send({ username, password });
+    const cookie = response.headers['set-cookie'];
+    expect(response.statusCode).toBe(200);
+    let user = response.body;
+
+    response = await request(app)
+      .post('/create_community')
+      .set('Cookie', cookie)
+      .send({ name, description, mods: [user._id] });
+    expect(response.statusCode).toBe(200);
+    const community = response.body._id;
+
+    response = await request(app).post('/board').set('Cookie', cookie).send({ name, community });
+    expect(response.statusCode).toBe(200);
+    let board = response.body._id;
+
+    const post = { content: 'Test' };
+    response = await request(app).post('/board/post').set('Cookie', cookie).send({ post, board, user: user._id });
+    expect(response.statusCode).toBe(200);
+    expect(response.body.content).toBe(post.content);
+
+    // should be in board
+    board = await Board.findById(board);
+    expect(board.posts.includes(response.body._id)).toBe(true);
+
+    // should be in user
+    user = await User.findById(user._id);
+    expect(user.posts.includes(response.body._id)).toBe(true);
+  });
+
+  it('should be compatible with DELETE /post', async () => {
+    const app = await createTestApp();
+    const username = 'username';
+    const password = 'password';
+    const name = 'name';
+    const description = 'description';
+
+    let response = await request(app).post('/create_user').send({ username, password });
+    const cookie = response.headers['set-cookie'];
+    expect(response.statusCode).toBe(200);
+    let user = response.body;
+
+    response = await request(app).post('/create_user').send({ username: 'wow', password });
+    const cookie2 = response.headers['set-cookie'];
+    expect(response.statusCode).toBe(200);
+    let user2 = response.body;
+
+    // user makes community
+    response = await request(app)
+      .post('/create_community')
+      .set('Cookie', cookie)
+      .send({ name, description, mods: [user._id] });
+    expect(response.statusCode).toBe(200);
+    const community = response.body._id;
+
+    response = await request(app).post('/board').set('Cookie', cookie).send({ name, community });
+    expect(response.statusCode).toBe(200);
+    let board = response.body._id;
+
+    // user posts in board
+    let post = { content: 'Test' };
+    response = await request(app).post('/board/post').set('Cookie', cookie).send({ post, board, user: user._id });
+    expect(response.statusCode).toBe(200);
+    expect(response.body.content).toBe(post.content);
+    post = response.body;
+
+    // user2 comments on post
+    let comment = { content: 'Test comment content' };
+    response = await request(app).post('/create_comment').set('Cookie', cookie2).send({ post: post._id, comment });
+    expect(response.statusCode).toBe(200);
+    comment = response.body;
+
+    // user2 likes post
+    response = await request(app).post('/like_post').set('Cookie', cookie2).send({ post: post._id });
+    expect(response.statusCode).toBe(200);
+
+    // there is one post in the board
+    board = await Board.findById(board);
+    expect(board.posts.length).toBe(1);
+    expect(board.posts.includes(post._id)).toBe(true);
+
+    // user has one post
+    user = await User.findById(user._id);
+    expect(user.posts.length).toBe(1);
+    expect(user.posts.includes(post._id)).toBe(true);
+
+    // user2 has one liked post and one comment
+    user2 = await User.findById(user2._id);
+    expect(user2.comments.length).toBe(1);
+    expect(user2.comments.includes(comment._id)).toBe(true);
+    expect(user2.liked_posts.length).toBe(1);
+    expect(user2.liked_posts.includes(post._id)).toBe(true);
+
+    // database has one comment and one post
+    expect((await Post.find()).length).toBe(1);
+    expect((await Comment.find()).length).toBe(1);
+
+    // user deletes their post
+    response = await request(app).delete('/post').set('Cookie', cookie).send({ post: post._id });
+    expect(response.statusCode).toBe(200);
+
+    // there are no posts in the board
+    board = await Board.findById(board);
+    expect(board.posts.length).toBe(0);
+
+    // user has 0 posts
+    user = await User.findById(user._id);
+    expect(user.posts.length).toBe(0);
+
+    // user2 has 0 liked posts and 0 comments
+    user2 = await User.findById(user2._id);
+    expect(user2.comments.length).toBe(0);
+    expect(user2.liked_posts.length).toBe(0);
+
+    // database has 0 comments and 0 posts
+    expect((await Post.find()).length).toBe(0);
+    expect((await Comment.find()).length).toBe(0);
   });
 });

--- a/backend/tests/integration/communities/boards/endpoints.test.js
+++ b/backend/tests/integration/communities/boards/endpoints.test.js
@@ -1,0 +1,144 @@
+import request from 'supertest';
+
+import createTestApp from '../../../../src/debug/test-app.js';
+import useMongoTestWrapper from '../../../../src/debug/jest-mongo.js';
+import { Community } from '../../../../src/communities/schemas.js';
+
+describe('POST /create_board', () => {
+  useMongoTestWrapper();
+
+  it('should fail with missing body params', async () => {
+    const app = await createTestApp();
+    const name = 'board';
+    const community = 'fakeId';
+
+    let response = await request(app).post('/create_board').send({});
+    expect(response.statusCode).toBe(400);
+
+    response = await request(app).post('/create_board').send({ name });
+    expect(response.statusCode).toBe(400);
+
+    response = await request(app).post('/create_board').send({ community });
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('should fail with invalid community', async () => {
+    const app = await createTestApp();
+    const name = 'board';
+    const community = 'fakeId';
+
+    let response = await request(app).post('/create_board').send({ name, community });
+    expect(response.statusCode).toBe(404);
+  });
+
+  it('should fail when not logged in', async () => {
+    const app = await createTestApp();
+    const username = 'username';
+    const password = 'password';
+    const name = 'board';
+
+    let response = await request(app).post('/create_user').send({ username, password });
+    expect(response.statusCode).toBe(200);
+    const cookie = response.headers['set-cookie'];
+    const user = response.body;
+
+    const comm_name = 'test community';
+    const comm_desc = 'a test community';
+    response = await request(app)
+      .post('/create_community')
+      .set('Cookie', cookie)
+      .send({ name: comm_name, description: comm_desc, mods: [user._id] });
+    expect(response.statusCode).toBe(200);
+    const community = response.body._id;
+
+    response = await request(app).post('/create_board').send({ name, community });
+    expect(response.statusCode).toBe(401);
+  });
+
+  it('should fail when not mod', async () => {
+    const app = await createTestApp();
+    const username = 'username';
+    const password = 'password';
+    const name = 'board';
+
+    let response = await request(app).post('/create_user').send({ username, password });
+    expect(response.statusCode).toBe(200);
+    const cookie = response.headers['set-cookie'];
+    const user = response.body;
+
+    response = await request(app).post('/create_user').send({ username: 'wow', password });
+    expect(response.statusCode).toBe(200);
+    const cookie2 = response.headers['set-cookie'];
+    const user2 = response.body;
+
+    const comm_name = 'test community';
+    const comm_desc = 'a test community';
+    response = await request(app)
+      .post('/create_community')
+      .set('Cookie', cookie2)
+      .send({ name: comm_name, description: comm_desc, mods: [user2._id] });
+    expect(response.statusCode).toBe(200);
+    const community = response.body._id;
+
+    response = await request(app).post('/create_board').set('Cookie', cookie).send({ name, community });
+    expect(response.statusCode).toBe(403);
+  });
+
+  it('should return board and update community', async () => {
+    const app = await createTestApp();
+    const username = 'username';
+    const password = 'password';
+    const name = 'board';
+
+    let response = await request(app).post('/create_user').send({ username, password });
+    expect(response.statusCode).toBe(200);
+    const cookie = response.headers['set-cookie'];
+    const user = response.body;
+
+    const comm_name = 'test community';
+    const comm_desc = 'a test community';
+    response = await request(app)
+      .post('/create_community')
+      .set('Cookie', cookie)
+      .send({ name: comm_name, description: comm_desc, mods: [user._id] });
+    expect(response.statusCode).toBe(200);
+    let community = response.body._id;
+
+    response = await request(app).post('/create_board').set('Cookie', cookie).send({ name, community });
+    expect(response.statusCode).toBe(200);
+    const board = response.body;
+    expect(board.name).toBe(name);
+    expect(board.parent).toBe(community);
+
+    community = await Community.findById(community);
+    expect(community.boards.length).toBe(1);
+    expect(community.boards.includes(board._id)).toBe(true);
+  });
+
+  it('should fail when board name is already in use', async () => {
+    const app = await createTestApp();
+    const username = 'username';
+    const password = 'password';
+    const name = 'board';
+
+    let response = await request(app).post('/create_user').send({ username, password });
+    expect(response.statusCode).toBe(200);
+    const cookie = response.headers['set-cookie'];
+    const user = response.body;
+
+    const comm_name = 'test community';
+    const comm_desc = 'a test community';
+    response = await request(app)
+      .post('/create_community')
+      .set('Cookie', cookie)
+      .send({ name: comm_name, description: comm_desc, mods: [user._id] });
+    expect(response.statusCode).toBe(200);
+    let community = response.body._id;
+
+    response = await request(app).post('/create_board').set('Cookie', cookie).send({ name, community });
+    expect(response.statusCode).toBe(200);
+
+    response = await request(app).post('/create_board').set('Cookie', cookie).send({ name, community });
+    expect(response.statusCode).toBe(409);
+  });
+});

--- a/backend/tests/integration/communities/boards/endpoints.test.js
+++ b/backend/tests/integration/communities/boards/endpoints.test.js
@@ -5,7 +5,7 @@ import useMongoTestWrapper from '../../../../src/debug/jest-mongo.js';
 import { Community } from '../../../../src/communities/schemas.js';
 import { Board } from '../../../../src/communities/boards/schemas.js';
 
-describe('POST /create_board', () => {
+describe('POST /board', () => {
   useMongoTestWrapper();
 
   it('should fail with missing body params', async () => {
@@ -13,13 +13,13 @@ describe('POST /create_board', () => {
     const name = 'board';
     const community = 'fakeId';
 
-    let response = await request(app).post('/create_board').send({});
+    let response = await request(app).post('/board').send({});
     expect(response.statusCode).toBe(400);
 
-    response = await request(app).post('/create_board').send({ name });
+    response = await request(app).post('/board').send({ name });
     expect(response.statusCode).toBe(400);
 
-    response = await request(app).post('/create_board').send({ community });
+    response = await request(app).post('/board').send({ community });
     expect(response.statusCode).toBe(400);
   });
 
@@ -28,7 +28,7 @@ describe('POST /create_board', () => {
     const name = 'board';
     const community = 'fakeId';
 
-    let response = await request(app).post('/create_board').send({ name, community });
+    let response = await request(app).post('/board').send({ name, community });
     expect(response.statusCode).toBe(404);
   });
 
@@ -52,7 +52,7 @@ describe('POST /create_board', () => {
     expect(response.statusCode).toBe(200);
     const community = response.body._id;
 
-    response = await request(app).post('/create_board').send({ name, community });
+    response = await request(app).post('/board').send({ name, community });
     expect(response.statusCode).toBe(401);
   });
 
@@ -81,7 +81,7 @@ describe('POST /create_board', () => {
     expect(response.statusCode).toBe(200);
     const community = response.body._id;
 
-    response = await request(app).post('/create_board').set('Cookie', cookie).send({ name, community });
+    response = await request(app).post('/board').set('Cookie', cookie).send({ name, community });
     expect(response.statusCode).toBe(403);
   });
 
@@ -105,7 +105,7 @@ describe('POST /create_board', () => {
     expect(response.statusCode).toBe(200);
     let community = response.body._id;
 
-    response = await request(app).post('/create_board').set('Cookie', cookie).send({ name, community });
+    response = await request(app).post('/board').set('Cookie', cookie).send({ name, community });
     expect(response.statusCode).toBe(200);
     const board = response.body;
     expect(board.name).toBe(name);
@@ -136,10 +136,10 @@ describe('POST /create_board', () => {
     expect(response.statusCode).toBe(200);
     let community = response.body._id;
 
-    response = await request(app).post('/create_board').set('Cookie', cookie).send({ name, community });
+    response = await request(app).post('/board').set('Cookie', cookie).send({ name, community });
     expect(response.statusCode).toBe(200);
 
-    response = await request(app).post('/create_board').set('Cookie', cookie).send({ name, community });
+    response = await request(app).post('/board').set('Cookie', cookie).send({ name, community });
     expect(response.statusCode).toBe(409);
   });
 });
@@ -186,7 +186,7 @@ describe('DELETE /board', () => {
     expect(response.statusCode).toBe(200);
     const community = response.body._id;
 
-    response = await request(app).post('/create_board').set('Cookie', cookie).send({ name, community });
+    response = await request(app).post('/board').set('Cookie', cookie).send({ name, community });
     expect(response.statusCode).toBe(200);
     let board = response.body._id;
 
@@ -219,7 +219,7 @@ describe('DELETE /board', () => {
     expect(response.statusCode).toBe(200);
     const community = response.body._id;
 
-    response = await request(app).post('/create_board').set('Cookie', cookie2).send({ name, community });
+    response = await request(app).post('/board').set('Cookie', cookie2).send({ name, community });
     expect(response.statusCode).toBe(200);
     let board = response.body._id;
 
@@ -247,7 +247,7 @@ describe('DELETE /board', () => {
     expect(response.statusCode).toBe(200);
     let community = response.body._id;
 
-    response = await request(app).post('/create_board').set('Cookie', cookie).send({ name, community });
+    response = await request(app).post('/board').set('Cookie', cookie).send({ name, community });
     expect(response.statusCode).toBe(200);
     const board = response.body;
     expect(board.name).toBe(name);
@@ -311,7 +311,7 @@ describe('GET /board', () => {
     expect(response.statusCode).toBe(200);
     let community = response.body._id;
 
-    response = await request(app).post('/create_board').set('Cookie', cookie).send({ name, community });
+    response = await request(app).post('/board').set('Cookie', cookie).send({ name, community });
     expect(response.statusCode).toBe(200);
     const board = response.body;
 
@@ -365,7 +365,7 @@ describe('GET /community/boards', () => {
     expect(response.statusCode).toBe(200);
     let community = response.body._id;
 
-    response = await request(app).post('/create_board').set('Cookie', cookie).send({ name, community });
+    response = await request(app).post('/board').set('Cookie', cookie).send({ name, community });
     expect(response.statusCode).toBe(200);
     const board = response.body;
 

--- a/backend/tests/integration/communities/endpoints.test.js
+++ b/backend/tests/integration/communities/endpoints.test.js
@@ -289,7 +289,7 @@ describe('DELETE /community', () => {
 
     // user makes board
     response = await request(app)
-      .post('/create_board')
+      .post('/board')
       .set('Cookie', cookie)
       .send({ name: 'board', community: community._id });
     expect(response.statusCode).toBe(200);

--- a/backend/tests/integration/communities/endpoints.test.js
+++ b/backend/tests/integration/communities/endpoints.test.js
@@ -5,6 +5,7 @@ import useMongoTestWrapper from '../../../src/debug/jest-mongo.js';
 import { User } from '../../../src/authentication/schemas.js';
 import { Community } from '../../../src/communities/schemas.js';
 import { Post } from '../../../src/communities/posts/schemas.js';
+import { Board } from '../../../src/communities/boards/schemas.js';
 
 describe('GET /search_users', () => {
   useMongoTestWrapper();
@@ -286,6 +287,14 @@ describe('DELETE /community', () => {
     expect(response.statusCode).toBe(200);
     let community = response.body;
 
+    // user makes board
+    response = await request(app)
+      .post('/create_board')
+      .set('Cookie', cookie)
+      .send({ name: 'board', community: community._id });
+    expect(response.statusCode).toBe(200);
+    let board = response.body;
+
     // user posts in community
     let post = { content: 'Test' };
     response = await request(app)
@@ -296,14 +305,17 @@ describe('DELETE /community', () => {
     expect(response.body.content).toBe(post.content);
     post = response.body;
 
-    // database has one community and one post
+    // database has one community, one post, one board
     expect((await Community.find()).length).toBe(1);
     expect((await Post.find()).length).toBe(1);
+    expect((await Board.find()).length).toBe(1);
 
-    // community has one post
+    // community has one post and one board
     community = await Community.findById(community._id);
     expect(community.posts.length).toBe(1);
     expect(community.posts.includes(post._id)).toBe(true);
+    expect(community.boards.length).toBe(1);
+    expect(community.boards.includes(board._id)).toBe(true);
 
     // user mod_for has one and one post
     user = await User.findById(user._id);
@@ -316,9 +328,10 @@ describe('DELETE /community', () => {
     response = await request(app).delete('/community').set('Cookie', cookie).send({ community: community._id });
     expect(response.statusCode).toBe(200);
 
-    // database has no communities and no posts
+    // database has no communities, no posts, no boards
     expect((await Community.find()).length).toBe(0);
     expect((await Post.find()).length).toBe(0);
+    expect((await Board.find()).length).toBe(0);
 
     // user mod_for has 0 and no posts
     user = await User.findById(user._id);


### PR DESCRIPTION
Adds boards as children of communities. Boards can be posted into the same way as communities. 

The current implementation of posts directly into communities is still supported and has not been touched, but the frontend should switch to board posts moving forward.

New endpoints:
POST /board
DELETE /board
GET /board
GET /community/boards
POST /board/post
GET /board/posts

Note that posts created using POST /board/post are deleted using DELETE /post and retrieved using GET /post.

Note that deleteRecursive() for community also deletes boards. Deleting boards deletes posts contained within them and removes from the parent's boards list. 