### PR TITLE
Feeds BE

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -220,6 +220,22 @@ Error
 "Not logged in"
 ```
 
+### GET /feed?page(optional)=Int&count(optional)=Int
+
+If logged in, returns date descending Post list of posts from followed communities, populates the board and community
+
+Params:
+count: max number of posts to return
+page: how count length offsets from most recent feed post
+Note: If count or page are used they must both be incuded, not setting page or count returns all feed posts
+
+Errors
+
+```
+401,
+400
+```
+
 ### POST /create_community
 
 Body

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -5,6 +5,7 @@ import useAuthentication from './authentication/index.js';
 import useCommunities from './communities/index.js';
 import useUser from './user/index.js';
 import useUploads from './uploads/index.js';
+import useFeeds from './feeds/index.js';
 
 export default async function createApp(options) {
   // set up express and define app
@@ -23,6 +24,9 @@ export default async function createApp(options) {
 
   // use users
   app = useUser(app);
+
+  // use feeds
+  app = useFeeds(app);
 
   return app;
 }

--- a/backend/src/feeds/endpoints.js
+++ b/backend/src/feeds/endpoints.js
@@ -19,8 +19,20 @@ export async function getFeed(req, res) {
   let count = countQ ? countQ : 0;
   let offset = pageQ ? pageQ * count : 0;
 
+  // count and offset need to be non-negative
+  if (count < 0 || offset < 0) {
+    count = 0;
+    offset = 0;
+  }
+
   // get user and followed communities
   let user = await User.findById(req.user._id).populate('followed_communities');
+
+  // if no followed communities send empty
+  if (user.followed_communities.length == 0) {
+    res.status(200).send([]);
+    return;
+  }
 
   // add all communty ids and all board ids
   let included_parent_ids = [];

--- a/backend/src/feeds/endpoints.js
+++ b/backend/src/feeds/endpoints.js
@@ -1,0 +1,49 @@
+import { User } from '../authentication/schemas.js';
+import { Post } from '../communities/posts/schemas.js';
+
+export async function getFeed(req, res) {
+  // must be logged in
+  if (!req.isAuthenticated()) {
+    res.status(401).send({ error: 'not logged in' });
+    return;
+  }
+
+  // get page and count, if none given return all
+  let countQ = req.query.count;
+  let pageQ = req.query.page;
+  let bothQ = countQ && pageQ;
+  if ((countQ || pageQ) && !bothQ) {
+    res.status(400).send({ error: 'count and page must both be sent or not at all' });
+    return;
+  }
+  let count = countQ ? countQ : 0;
+  let offset = pageQ ? pageQ * count : 0;
+
+  // get user and followed communities
+  let user = await User.findById(req.user._id).populate('followed_communities');
+
+  // add all communty ids and all board ids
+  let included_parent_ids = [];
+  for (let comm of user.followed_communities) {
+    included_parent_ids.push({ parent: comm._id });
+    for (let board of comm.boards) {
+      included_parent_ids.push({ parent: board });
+    }
+  }
+
+  // find Posts that match, populate the community and board, sort date descending
+  let results = await Post.find({ $or: included_parent_ids })
+    .populate({
+      path: 'parent',
+      populate: {
+        path: 'parent',
+        strictPopulate: false,
+      },
+      strictPopulate: false,
+    })
+    .sort({ _id: -1 })
+    .limit(count)
+    .skip(offset);
+
+  res.status(200).send(results);
+}

--- a/backend/src/feeds/index.js
+++ b/backend/src/feeds/index.js
@@ -1,0 +1,7 @@
+import { getFeed } from './endpoints.js';
+
+export default function useFeeds(app) {
+  app.get('/feed', getFeed);
+
+  return app;
+}

--- a/backend/tests/integration/feeds/endpoints.test.js
+++ b/backend/tests/integration/feeds/endpoints.test.js
@@ -1,0 +1,193 @@
+import request from 'supertest';
+
+import createTestApp from '../../../src/debug/test-app.js';
+import useMongoTestWrapper from '../../../src/debug/jest-mongo.js';
+
+import { Community } from '../../../src/communities/schemas.js';
+import { User } from '../../../src/authentication/schemas.js';
+import { Post } from '../../../src/communities/posts/schemas.js';
+import { Comment } from '../../../src/communities/posts/comments/schemas.js';
+
+describe('GET /feed', () => {
+  useMongoTestWrapper();
+
+  it('should fail if not logged in', async () => {
+    const app = await createTestApp();
+
+    let response = await request(app).get('/feed');
+    expect(response.statusCode).toBe(401);
+  });
+
+  it('should fail if params used but not both', async () => {
+    const app = await createTestApp();
+
+    const username = 'username';
+    const password = 'password';
+
+    let response = await request(app).post('/create_user').send({ username, password });
+    const cookie = response.headers['set-cookie'];
+    expect(response.statusCode).toBe(200);
+    const user = response.body;
+
+    response = await request(app).get('/feed?count=0').set('Cookie', cookie);
+    expect(response.statusCode).toBe(400);
+
+    response = await request(app).get('/feed?page=0').set('Cookie', cookie);
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('should return empty if no followed communities', async () => {
+    const app = await createTestApp();
+
+    const username = 'username';
+    const password = 'password';
+
+    let response = await request(app).post('/create_user').send({ username, password });
+    const cookie = response.headers['set-cookie'];
+    expect(response.statusCode).toBe(200);
+    const user = response.body;
+
+    response = await request(app).get('/feed').set('Cookie', cookie);
+    expect(response.statusCode).toBe(200);
+    expect(response.body.toString() == [].toString()).toBe(true);
+  });
+
+  it('should return populated posts only from followed communities', async () => {
+    const app = await createTestApp();
+
+    const username = 'username';
+    const password = 'password';
+    const name = 'name';
+    const description = 'description';
+
+    let response = await request(app).post('/create_user').send({ username, password });
+    const cookie = response.headers['set-cookie'];
+    expect(response.statusCode).toBe(200);
+    const user = response.body;
+
+    response = await request(app)
+      .post('/create_community')
+      .set('Cookie', cookie)
+      .send({ name, description, mods: [user._id] });
+    expect(response.statusCode).toBe(200);
+    const community = response.body._id;
+
+    response = await request(app).post('/board').set('Cookie', cookie).send({ name, community });
+    expect(response.statusCode).toBe(200);
+    let board = response.body._id;
+
+    const post = { content: 'Test' };
+    response = await request(app).post('/board/post').set('Cookie', cookie).send({ post, board });
+    expect(response.statusCode).toBe(200);
+    let post1 = response.body._id;
+
+    response = await request(app).post('/board/post').set('Cookie', cookie).send({ post, board });
+    expect(response.statusCode).toBe(200);
+    let post2 = response.body._id;
+
+    response = await request(app).post('/user/follow_community').set('Cookie', cookie).send({ id: community });
+    expect(response.statusCode).toBe(200);
+
+    response = await request(app)
+      .post('/create_community')
+      .set('Cookie', cookie)
+      .send({ name: 'com2', description, mods: [user._id] });
+    expect(response.statusCode).toBe(200);
+    const community2 = response.body._id;
+
+    response = await request(app).post('/board').set('Cookie', cookie).send({ name, community: community2 });
+    expect(response.statusCode).toBe(200);
+    let board2 = response.body._id;
+
+    response = await request(app).post('/board/post').set('Cookie', cookie).send({ post, board: board2 });
+    expect(response.statusCode).toBe(200);
+    let post3 = response.body._id;
+
+    response = await request(app).get('/feed').set('Cookie', cookie);
+    expect(response.statusCode).toBe(200);
+    expect(response.body.length).toBe(2);
+    expect(response.body[0]._id).toBe(post2);
+    expect(response.body[0].parent._id).toBe(board);
+    expect(response.body[0].parent.parent._id).toBe(community);
+    expect(response.body[1]._id).toBe(post1);
+  });
+
+  it('should paginate', async () => {
+    const app = await createTestApp();
+
+    const username = 'username';
+    const password = 'password';
+    const name = 'name';
+    const description = 'description';
+
+    let response = await request(app).post('/create_user').send({ username, password });
+    const cookie = response.headers['set-cookie'];
+    expect(response.statusCode).toBe(200);
+    const user = response.body;
+
+    response = await request(app)
+      .post('/create_community')
+      .set('Cookie', cookie)
+      .send({ name, description, mods: [user._id] });
+    expect(response.statusCode).toBe(200);
+    const community = response.body._id;
+
+    response = await request(app).post('/board').set('Cookie', cookie).send({ name, community });
+    expect(response.statusCode).toBe(200);
+    let board = response.body._id;
+
+    const post = { content: 'Test' };
+    response = await request(app).post('/board/post').set('Cookie', cookie).send({ post, board });
+    expect(response.statusCode).toBe(200);
+    let post1 = response.body._id;
+
+    response = await request(app).post('/board/post').set('Cookie', cookie).send({ post, board });
+    expect(response.statusCode).toBe(200);
+    let post2 = response.body._id;
+
+    response = await request(app).post('/board/post').set('Cookie', cookie).send({ post, board });
+    expect(response.statusCode).toBe(200);
+    let post3 = response.body._id;
+
+    response = await request(app).post('/user/follow_community').set('Cookie', cookie).send({ id: community });
+    expect(response.statusCode).toBe(200);
+
+    response = await request(app)
+      .post('/create_community')
+      .set('Cookie', cookie)
+      .send({ name: 'com2', description, mods: [user._id] });
+    expect(response.statusCode).toBe(200);
+    const community2 = response.body._id;
+
+    response = await request(app).post('/board').set('Cookie', cookie).send({ name, community: community2 });
+    expect(response.statusCode).toBe(200);
+    let board2 = response.body._id;
+
+    response = await request(app).post('/board/post').set('Cookie', cookie).send({ post, board: board2 });
+    expect(response.statusCode).toBe(200);
+    let post4 = response.body._id;
+
+    response = await request(app).get('/feed?page=0&count=2').set('Cookie', cookie);
+    expect(response.statusCode).toBe(200);
+    expect(response.body.length).toBe(2);
+    expect(response.body[0]._id).toBe(post3);
+    expect(response.body[1]._id).toBe(post2);
+
+    response = await request(app).get('/feed?page=1&count=2').set('Cookie', cookie);
+    expect(response.statusCode).toBe(200);
+    expect(response.body.length).toBe(1);
+    expect(response.body[0]._id).toBe(post1);
+
+    response = await request(app).get('/feed?page=2&count=2').set('Cookie', cookie);
+    expect(response.statusCode).toBe(200);
+    expect(response.body.length).toBe(0);
+
+    response = await request(app).get('/feed?page=0&count=0').set('Cookie', cookie);
+    expect(response.statusCode).toBe(200);
+    expect(response.body.length).toBe(3);
+
+    response = await request(app).get('/feed?page=-1&count=-1').set('Cookie', cookie);
+    expect(response.statusCode).toBe(200);
+    expect(response.body.length).toBe(3);
+  });
+});


### PR DESCRIPTION
Added GET /feed

Returns posts from communities you follow and boards in communities you follow, sorted by new first. The parent and parent.parent are populated so no extra requests are needed to show the board and community name.

Has optional "count" and "page" to limit results and paginate.